### PR TITLE
cmake: remove include references to config.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,6 @@ project(carl9170)
 #if you don't want the full compiler output, remove the following line
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 
-include("config.cmake")
-
 add_subdirectory(carlfw)
 
 if (CONFIG_CARL9170FW_BUILD_MINIBOOT)

--- a/carlfw/CMakeLists.txt
+++ b/carlfw/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 2.8)
 project(carl9170.fw)
 
 include("../extra/sh-elf-linux.cmake")
-include("../config.cmake")
 
 set(CARL9170_FW_ELF carl9170.elf)
 set(CARLFW_CFLAGS_WARNING "-W -Wall -Wextra -Wunreachable-code -Winline -Wlogical-op -Wno-packed-bitfield-compat -Winit-self -Wshadow -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wformat=2 -Wcast-align -Wmissing-format-attribute -Wmissing-prototypes -Wtype-limits -Wmissing-declarations -Wmissing-noreturn -Wredundant-decls -Wnested-externs -Wdisabled-optimization -Wpointer-arith -Wvolatile-register-var -Waddress -Wbad-function-cast -Wunsafe-loop-optimizations")

--- a/minifw/CMakeLists.txt
+++ b/minifw/CMakeLists.txt
@@ -3,7 +3,6 @@ cmake_minimum_required(VERSION 2.8)
 project(miniboot.fw)
 
 include("../extra/sh-elf-linux.cmake")
-include("../config.cmake")
 
 set(miniboot_src miniboot.S)
 set_source_files_properties(miniboot.S PROPERTIES LANGUAGE C)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,8 +8,6 @@ endif (CONFIG_CARL9170FW_MAKE_RELEASE)
 
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/extra)
 
-include("../config.cmake")
-
 include_directories (../include/linux ../include/shared ../include lib include)
 add_subdirectory(lib)
 add_subdirectory(src)


### PR DESCRIPTION
This file is required by the cmake scripts, but not provided by the repository.