### PR TITLE
carlfw: add stability fixes for AR9170 USB adapters

### DIFF
--- a/carlfw/src/cam.c
+++ b/carlfw/src/cam.c
@@ -42,31 +42,36 @@ static void enable_cam_user(const uint16_t userId)
 		orl(AR9170_MAC_REG_CAM_ROLL_CALL_TBL_H, (((uint32_t) 1) << (userId - 32)));
 }
 
+#define CAM_TIMEOUT	10000
+
 static void wait_for_cam_read_ready(void)
 {
-	while ((get(AR9170_MAC_REG_CAM_STATE) & AR9170_MAC_CAM_STATE_READ_PENDING) == 0) {
-		/*
-		 * wait
-		 */
+	unsigned int timeout = CAM_TIMEOUT;
+
+	while (((get(AR9170_MAC_REG_CAM_STATE) & AR9170_MAC_CAM_STATE_READ_PENDING) == 0) &&
+	       timeout--) {
+		/* wait */
 	}
 }
 
 static void wait_for_cam_write_ready(void)
 {
-	while ((get(AR9170_MAC_REG_CAM_STATE) & AR9170_MAC_CAM_STATE_WRITE_PENDING) == 0) {
-		/*
-		 * wait some more
-		 */
+	unsigned int timeout = CAM_TIMEOUT;
+
+	while (((get(AR9170_MAC_REG_CAM_STATE) & AR9170_MAC_CAM_STATE_WRITE_PENDING) == 0) &&
+	       timeout--) {
+		/* wait */
 	}
 }
 
 static void HW_CAM_Avail(void)
 {
+	unsigned int timeout = CAM_TIMEOUT;
 	uint32_t tmpValue;
 
 	do {
 		tmpValue = get(AR9170_MAC_REG_CAM_MODE);
-	} while (tmpValue & AR9170_MAC_CAM_HOST_PENDING);
+	} while ((tmpValue & AR9170_MAC_CAM_HOST_PENDING) && timeout--);
 }
 
 static void HW_CAM_Write128(const uint32_t address, const uint32_t *data)

--- a/carlfw/src/main.c
+++ b/carlfw/src/main.c
@@ -94,11 +94,16 @@ static void tally_update(void)
 
 		fw.tally.active += delta;
 
+		/*
+		 * Use HW cycle counter for CCA busy time instead of
+		 * single-bit polling. AR9170_MAC_REG_CHANNEL_BUSY is
+		 * a read-and-clear counter like AR9170_MAC_REG_RX_TOTAL.
+		 */
+		fw.tally.cca += get(AR9170_MAC_REG_CHANNEL_BUSY);
+
 		boff = get(AR9170_MAC_REG_BACKOFF_STATUS);
 		if (boff & AR9170_MAC_BACKOFF_TX_PE)
 			fw.tally.tx_time += delta;
-		if (boff & AR9170_MAC_BACKOFF_CCA)
-			fw.tally.cca += delta;
 	}
 #endif /* CONFIG_CARL9170FW_RADIO_FUNCTIONS */
 	fw.tally_clock = time;

--- a/carlfw/src/rf.c
+++ b/carlfw/src/rf.c
@@ -190,6 +190,15 @@ static uint32_t rf_init(const uint32_t delta_slope_coeff_exp,
 
 	ret = AGC_calibration(finiteLoopCount);
 
+	if (ret) {
+		/*
+		 * Calibration timed out — PHY is in an undefined state.
+		 * Disable baseband so the driver sees a clean failure
+		 * instead of operating with a half-initialized PHY.
+		 */
+		set(AR9170_PHY_REG_ACTIVE, AR9170_PHY_ACTIVE_DIS);
+	}
+
 	set_channel_end();
 	return ret;
 }

--- a/carlfw/src/wlan.c
+++ b/carlfw/src/wlan.c
@@ -77,7 +77,13 @@ static void wlan_check_rx_overrun(void)
 	fw.tally.rx_total += total = get(AR9170_MAC_REG_RX_TOTAL);
 	fw.tally.rx_overrun += overruns = get(AR9170_MAC_REG_RX_OVERRUN);
 	if (unlikely(overruns)) {
-		if (overruns == total) {
+		/*
+		 * Trigger MAC reset when more than half of received
+		 * frames are dropped.  The original check (overruns ==
+		 * total) only fired at 100 % loss, leaving the adapter
+		 * nearly blind at 95 % loss without any recovery.
+		 */
+		if (total && overruns > (total >> 1)) {
 			DBG("RX Overrun");
 			fw.wlan.mac_reset++;
 		}
@@ -100,10 +106,33 @@ static void handle_pretbtt(void)
 	fw.wlan.cab_flush_time = get_clock_counter();
 
 #ifdef CONFIG_CARL9170FW_RADIO_FUNCTIONS
-	rf_psm();
+	{
+		unsigned int prev_phy_state = fw.phy.state;
 
-	send_cmd_to_host(4, CARL9170_RSP_PRETBTT, 0x00,
-			 (uint8_t *) &fw.phy.psm.state);
+		rf_psm();
+
+		/*
+		 * After PSM wake, re-trigger TX DMA for queued frames.
+		 * While the PHY was off, the hardware could not transmit
+		 * and DMA trigger bits were consumed without effect.
+		 */
+		if (prev_phy_state == CARL9170_PHY_OFF &&
+		    fw.phy.state == CARL9170_PHY_ON) {
+			int i;
+			uint32_t trigger = 0;
+
+			for (i = AR9170_TXQ0; i <= AR9170_TXQ_SPECIAL; i++) {
+				if (!queue_empty(&fw.wlan.tx_queue[i]))
+					trigger |= BIT(i);
+			}
+
+			if (trigger)
+				wlan_trigger(trigger);
+		}
+
+		send_cmd_to_host(4, CARL9170_RSP_PRETBTT, 0x00,
+				 (uint8_t *) &fw.phy.psm.state);
+	}
 #endif /* CONFIG_CARL9170FW_RADIO_FUNCTIONS */
 }
 

--- a/carlfw/src/wlantx.c
+++ b/carlfw/src/wlantx.c
@@ -471,11 +471,10 @@ void handle_wlan_tx_completion(void)
 			}
 		}
 
-		wlan_tx_ampdu_reset(i);
-
 		for_each_desc(desc, &fw.wlan.tx_retry)
 			__wlan_tx(desc);
 
+		wlan_tx_ampdu_reset(i);
 		wlan_tx_ampdu_end(i);
 		if (!queue_empty(&fw.wlan.tx_queue[i]))
 			wlan_trigger(BIT(i));

--- a/carlfw/usb/main.c
+++ b/carlfw/usb/main.c
@@ -295,6 +295,63 @@ static void disable_watchdog(void)
 	set(AR9170_TIMER_REG_WATCH_DOG, 0xffff);
 }
 
+/*
+ * Warm reset: re-initialize firmware without destroying USB PHY state.
+ * This allows the host to re-enumerate the device after a USB bus reset
+ * without requiring a physical re-plug.
+ *
+ * Unlike reboot() which calls turn_power_off() and jump_to_bootcode(),
+ * this preserves the USB connection and jumps directly to start().
+ */
+static void __noreturn usb_warm_reset(void)
+{
+	disable_watchdog();
+
+	/* Disable baseband to stop PHY activity */
+	set(AR9170_PHY_REG_ACTIVE, AR9170_PHY_ACTIVE_DIS);
+
+	/* Stop WLAN DMA */
+	set(AR9170_MAC_REG_DMA_TRIGGER, 0);
+
+	/* Stop USB DMA without full power-off */
+	andl(AR9170_USB_REG_DMA_CTL, ~(AR9170_USB_DMA_CTL_ENABLE_TO_DEVICE |
+					AR9170_USB_DMA_CTL_ENABLE_FROM_DEVICE));
+
+	/* Reset PTA component */
+	orl(AR9170_PTA_REG_DMA_MODE_CTRL, AR9170_PTA_DMA_MODE_CTRL_RESET);
+	andl(AR9170_PTA_REG_DMA_MODE_CTRL, ~AR9170_PTA_DMA_MODE_CTRL_RESET);
+
+	/* Reset MAC power state */
+	set(AR9170_MAC_REG_POWER_STATE_CTRL,
+	    AR9170_MAC_POWER_STATE_CTRL_RESET);
+
+	/*
+	 * Hardware reset: WLAN MAC, DMA engine, and baseband.
+	 * Without this, the PHY/RF can lock up after repeated
+	 * warm resets, causing -ETIMEDOUT on register writes
+	 * and cascading driver reloads (phy0 -> phy29 -> crash).
+	 *
+	 * BB_WARM_RESET resets PHY logic while preserving
+	 * calibration-friendly state. start() -> init() will
+	 * reconfigure everything via the driver anyway.
+	 */
+	set(AR9170_PWR_REG_RESET, AR9170_PWR_RESET_COMMIT_RESET_MASK |
+				  AR9170_PWR_RESET_WLAN_MASK |
+				  AR9170_PWR_RESET_DMA_MASK |
+				  AR9170_PWR_RESET_BB_WARM_RESET);
+	set(AR9170_PWR_REG_RESET, 0x0);
+
+	/* Clean DMA memory */
+	memset(&dma_mem, 0, sizeof(dma_mem));
+
+	/* Clear firmware state */
+	memset(&fw, 0, sizeof(fw));
+
+	/* Re-enter firmware from start() which does full init
+	 * and sends CARL9170_RSP_BOOT to the host. */
+	start();
+}
+
 void __noreturn reboot(void)
 {
 	disable_watchdog();
@@ -377,7 +434,7 @@ static void usb_handler(uint8_t usb_interrupt_level1)
 		if (usb_interrupt_level2 & AR9170_USB_INTR_SRC7_USB_RESET) {
 			usb_reset_ack();
 			usb_reset_eps();
-			reboot();
+			usb_warm_reset();
 		}
 
 		if (usb_interrupt_level2 & AR9170_USB_INTR_SRC7_USB_SUSPEND) {
@@ -409,7 +466,7 @@ static void usb_handler(uint8_t usb_interrupt_level1)
 			fw.suspend_mode = CARL9170_HOST_AWAKE;
 			set(AR9170_USB_REG_WAKE_UP, 0);
 
-			reboot();
+			usb_warm_reset();
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Seven targeted stability and performance fixes for AR9170 (AR9001U) USB WiFi adapters, tested on AVM FRITZ!WLAN USB Stick N (057c:8401) running Kali Linux 6.18.

- **USB warm reset**: replace `reboot()` with `usb_warm_reset()` preserving USB PHY state, includes MAC/DMA/BB hardware reset via `AR9170_PWR_REG_RESET` to prevent PHY lockup after repeated bus resets
- **CAM timeouts**: add `CAM_TIMEOUT` guards to three infinite wait loops in the security engine
- **CCA HW counter**: use `AR9170_MAC_REG_CHANNEL_BUSY` read-and-clear counter instead of single-bit backoff polling for accurate survey data
- **RX overrun recovery**: lower MAC reset threshold from 100% to >50% frame drop
- **AGC calibration failsafe**: disable baseband on calibration timeout instead of leaving PHY half-initialized
- **AMPDU retry ordering**: move `wlan_tx_ampdu_reset()` after retry queue processing to preserve `ba_end` markers
- **PSM TX DMA re-trigger**: after power save wake, re-trigger TX DMA queues for frames that were queued while the PHY was off — DMA trigger bits were consumed without effect while the radio was sleeping

## Problem

Without the warm reset fix, repeated USB bus resets cause cascading driver reloads (phy0 → phy29) ending in `-ETIMEDOUT` on PHY register writes and system crash. The original `reboot()` path kills the USB connection requiring physical re-plug.

The PSM fix addresses a bug where `handle_pretbtt()` calls `rf_psm()` to wake the PHY but never re-triggers TX DMA. While the PHY was off, the hardware consumed DMA trigger bits without actually transmitting, leaving queued frames stuck after wake-up.

The remaining fixes address edge cases in RX recovery, RF initialization, and HT aggregation that degrade stability on 5 GHz HT40 connections.

## Scope

These patches address all software-fixable firmware issues. The known hardware limitation — QoS and AMPDU being mutually exclusive due to the MAC only supporting aggregation on HW queue 0 (documented in `include/shared/wlan.h:407-423`) — is **not** addressed here as it requires hardware changes.

## Test plan

- [x] Firmware compiles cleanly with sh-elf-gcc 15.2.0 (12,712 bytes, API 1.9.9)
- [x] Driver reload via `modprobe -r carl9170 && modprobe carl9170` works without re-plug
- [x] 5 GHz HT40 connection stable (0% packet loss, -35 dBm)
- [x] Association succeeds on first attempt (no status=30 rejection)
- [x] Integration test suite passes (9/9 pass, 1 skip)
- [ ] Long-term stability test (>24h)
- [ ] 2.4 GHz band test